### PR TITLE
add necessary blank line for formatting

### DIFF
--- a/docs/securebuild-lab/create-server.md
+++ b/docs/securebuild-lab/create-server.md
@@ -95,6 +95,7 @@ You will be assigned a number for the lab so as not to interfere with other user
     ``` bash
     echo "export HPVS_NUMBER='${HPVS_NUMBER}'" >> "${HOME}/.bashrc"
     ```
+    
 3. Set Secure Build Server Port
 
     ``` bash


### PR DESCRIPTION
A blank line was needed after step 2 in the "Set your provided number and save it for later use" subsection so that step numbering would be correct.  (It went 2. 3. 3. ... previously but this will fix it to 2. 3. 4. ...)