### PR TITLE
remove empty arrays from sb_config.yaml

### DIFF
--- a/docs/securebuild-lab/build.md
+++ b/docs/securebuild-lab/build.md
@@ -163,10 +163,6 @@ source "${HOME}/.bashrc"
             repo: '${DOCKER_USERNAME}/${IMAGE_NAME}'
             image_tag_prefix: 'latest'
             content_trust_base: 'False'
-        env:
-            whitelist: []
-        build:
-            args: []
         signing_key:
             private_key_path: '${SB_DIR}/registration_keys/${keyName}.private'
             public_key_path: '${SB_DIR}/registration_keys/${keyName}.pub'


### PR DESCRIPTION
The GA code doesn't like the empty 'env.whitelist' array- at least it gives a nice error message- and it likes the empty 'build.args' array even less-  it gives a Go panic to this.  I've remove both of them.

(the error message and Go panic were occurring on the next step, the 'hpvs sb init' command)