### PR TITLE
add --force option to hpvs repository delete

### DIFF
--- a/docs/securebuild-lab/cleanup.md
+++ b/docs/securebuild-lab/cleanup.md
@@ -39,7 +39,7 @@ source "${HOME}/.bashrc"
 ## Cleanup Repository
 
 ``` bash
-hpvs repository  delete --id ${REPO_ID}
+hpvs repository  delete --id ${REPO_ID} --force
 ```
 
 ???+ example "Example Output"


### PR DESCRIPTION
contrary to having to do a lot of parsing to get the image id,  just adding --force to the hpvs repository delete will also get rid of the image.  seems like the most expedient course of action for the lab.