### PR TITLE
Fixes following warning message caused by moving the assignments page out of the individual lab directories while leaving the page itself in the nav.

### DIFF
--- a/docs/grep11-lab/assignments.md
+++ b/docs/grep11-lab/assignments.md
@@ -1,7 +1,0 @@
-# Grep11 Lab Assignments
-
-|Name|Skytap URL |Skytap Password| VPN ID|
-|:--:|:---------:|:-------------:|:-----:|
-|this|table|intentionally|left blank|
-
-


### PR DESCRIPTION
The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - grep11-lab/assignments.md